### PR TITLE
ENH: limit memory usage

### DIFF
--- a/examples/connectivity/plot_compare_resting_state_decomposition.py
+++ b/examples/connectivity/plot_compare_resting_state_decomposition.py
@@ -20,7 +20,7 @@ Available on https://hal.inria.fr/inria-00588898/en/
 ### Load ADHD rest dataset ####################################################
 from nilearn import datasets
 
-adhd_dataset = datasets.fetch_adhd()
+adhd_dataset = datasets.fetch_adhd(n_subjects=30)
 func_filenames = adhd_dataset.func  # list of 4D nifti files for each subject
 
 # print basic information on the dataset


### PR DESCRIPTION
Slight rework of mask_and_reduce to limit memory usage.

The trick is to delay as much as possible loading of data. It is critical
partly because things don't always get garbage collected as well as they
should, and data sticks around (nifti images may have references on data
after it's loaded, for instance).

The solution here is not satisfactory in the long run, but at least
it is now in constant memory usage, as before the big dict learning
refactoring.
